### PR TITLE
Add "ifContains" method for Colada\Collection, with tests

### DIFF
--- a/src/Colada/Collection.php
+++ b/src/Colada/Collection.php
@@ -416,4 +416,12 @@ interface Collection extends \JsonSerializable, \Traversable
      * @return \Colada\Collection
      */
     function __clone();
+
+    /**
+     * @param mixed $element
+     * @param callback $callback
+     *
+     * @return mixed
+     */
+    function ifContains($element, $callback);
 }

--- a/src/Colada/IteratorCollection.php
+++ b/src/Colada/IteratorCollection.php
@@ -776,4 +776,18 @@ class IteratorCollection
 
         $this->iterator = $collection->iterator;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function ifContains($element, $callback)
+    {
+        Contracts::ensureCallable($callback);
+
+        if ($this->contains($element)) {
+            return call_user_func($callback);
+        }
+
+        return $this;
+    }
 }

--- a/src/Colada/Tests/IteratorCollectionTest.php
+++ b/src/Colada/Tests/IteratorCollectionTest.php
@@ -465,4 +465,34 @@ class IteratorCollectionTest extends \PHPUnit_Framework_TestCase
 
         assertSame(true, $collection->isEmpty());
     }
+
+    /**
+     * @test
+     */
+    public function methodIfContainsShouldNotCallCallbackIfElementNotExists()
+    {
+        $collection = new IteratorCollection(new \ArrayIterator(array('pink', 'blue', 'red', 'green')));
+
+        $callback = function() {
+            throw new \Exception();
+        };
+
+        $collection->ifContains('black', $callback)->add('black')->toArray();
+    }
+
+    /**
+     * @test
+     *
+     * @expectedException \Exception
+     */
+    public function methodIfContainsShouldCallCallbackIfElementExists()
+    {
+        $collection = new IteratorCollection(new \ArrayIterator(array('pink', 'blue', 'red', 'green')));
+
+        $callback = function() {
+            throw new \Exception();
+        };
+
+        $collection->ifContains('pink', $callback)->add('pink')->toArray();
+    }
 }


### PR DESCRIPTION
Hello.

I really want something like this:

``` php
public function saveUser($newUser)
{
    collection($this->getAllUsers())->mapBy(x()->getEmail())->ifContains($newUser->getEmail(), function() {
        throw new DuplicateEmailException();
    });

    $this->save($newUser);
}
```

instead of this:

``` php
public function saveUser($newUser)
{
    if (collection($this->getAllUsers())->mapBy(x()->getEmail())->contains($newUser->getEmail())) {
        throw new DuplicateEmailException();
    }

    $this->save($newUser);
}
```
